### PR TITLE
Compile schemas once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,21 +19,23 @@ class Validator {
 	validate(options) {
 		// Self is a reference to the current Validator instance
 		var self = this;
+		const validateFunctions = Object.keys(options).map(function (requestProperty) {
+			let schema = options[requestProperty];
+			let validateFunction = this.ajv.compile(schema);
+			return [requestProperty, validateFunction];
+		}, self);
 
 		// The actual middleware function
 		return function (req, res, next) {
 			var validationErrors = {};
 
-			Object.keys(options).forEach(function (requestProperty) {
-				let schema = options[requestProperty];
-				let validateFunction = this.ajv.compile(schema);
-				let valid = validateFunction(req[requestProperty]);
-
+			for (const [requestProperty, validateFunction] of validateFunctions) {
+				const valid = validateFunction(req[requestProperty]);
 				if (!valid) {
 					validationErrors[requestProperty] = validateFunction.errors;
 				}
-			}, self);
-			
+			}
+
 			if (Object.keys(validationErrors).length != 0) {
 				next(new ValidationError(validationErrors));
 			} else {


### PR DESCRIPTION
#### Feature:

* Main goal: improve performance
* How? The schemas are compiled only once, when the
   `Validator#validate()` is invoked to produce a middleware.
   This is unlike previously, when `Ajv#compile()` was invoked
   on each request. In reality, Ajv caches compiled schemas:

   > Ajv compiles schemas to functions and caches them in all cases
   > (using schema serialized with fast-json-stable-stringify or a
   > custom function as a key), so that the next time the same schema
   > is used (not necessarily the same object instance) it won't be
   > compiled again.

   However:

   > The best performance is achieved when using compiled functions
   > returned by compile or getSchema methods (there is no additional
   > function call).

* Bonus: Using a `for` loop will allow us to allow stopping
   validation (loop) on first error (*as a separate feature (to be done!)*).

#### References:

* Ajv Readme: https://github.com/epoberezkin/ajv#readme
* Issue #44 (Performance improvements): https://github.com/JouzaLoL/express-json-validator-middleware/issues/14