### PR TITLE
Add regression coverage for ValidationError typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	"scripts": {
 		"test": "npm run test:unit && npm run test:types",
 		"test:unit": "tap",
-		"test:types": "tsc --noEmit --strict src/index.d.ts",
+		"test:types": "node scripts/test-types.js",
 		"lint": "eslint \"src/*.js\" --fix",
 		"prepush": "npm run lint && npm run test",
 		"prepublish": "npm run lint && npm run test"

--- a/scripts/test-types.js
+++ b/scripts/test-types.js
@@ -1,0 +1,80 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const repoRoot = path.resolve(__dirname, "..");
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ejvm-types-"));
+const tarballDir = path.join(tempDir, "tarballs");
+const sourcePath = path.join(tempDir, "validation-error.ts");
+
+function run(command, args, options = {}) {
+	const result = spawnSync(command, args, {
+		encoding: "utf8",
+		...options
+	});
+
+	if (result.status !== 0) {
+		process.stdout.write(result.stdout);
+		process.stderr.write(result.stderr);
+		process.exit(result.status || 1);
+	}
+
+	return result.stdout;
+}
+
+try {
+	fs.mkdirSync(tarballDir, { recursive: true });
+	fs.writeFileSync(
+		sourcePath,
+		[
+			'import { ValidationError } from "express-json-validator-middleware";',
+			"",
+			"const validationError = new ValidationError({",
+			"\tparams: [",
+			"\t\t{",
+			'\t\t\tinstancePath: "/id",',
+			'\t\t\tschemaPath: "#/properties/id/maxLength",',
+			'\t\t\tkeyword: "maxLength",',
+			"\t\t\tparams: { limit: 2 },",
+			'\t\t\tmessage: "should NOT be longer than 2 characters"',
+			"\t\t}",
+			"\t]",
+			"});",
+			"",
+			"validationError.validationErrors.params?.[0].keyword;",
+			""
+		].join("\n")
+	);
+
+	const tarballName = run(
+		"npm",
+		["pack", ".", "--pack-destination", tarballDir],
+		{ cwd: repoRoot }
+	).trim();
+
+	fs.writeFileSync(
+		path.join(tempDir, "package.json"),
+		JSON.stringify({ name: "ejvm-types-test", private: true }, null, 2)
+	);
+
+	run(
+		"npm",
+		[
+			"install",
+			"--ignore-scripts",
+			"--no-package-lock",
+			"typescript@4.9.5",
+			path.join(tarballDir, tarballName)
+		],
+		{ cwd: tempDir }
+	);
+
+	run(
+		path.join(tempDir, "node_modules", ".bin", "tsc"),
+		["--noEmit", "--strict", "--skipLibCheck", sourcePath],
+		{ cwd: tempDir }
+	);
+} finally {
+	fs.rmSync(tempDir, { force: true, recursive: true });
+}

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -1,8 +1,27 @@
 const { test } = require("tap");
 const Ajv = require("ajv");
 
-const { Validator } = require("../src");
+const { ValidationError, Validator } = require("../src");
 
 test("Validator instance", async t => {
 	t.type(new Validator().ajv, Ajv, " property `ajv` should be an Ajv instance");
+});
+
+test("ValidationError instance", async t => {
+	const validationErrors = {
+		params: [
+			{
+				instancePath: "/id",
+				schemaPath: "#/properties/id/maxLength",
+				keyword: "maxLength",
+				params: { limit: 2 },
+				message: "should NOT be longer than 2 characters"
+			}
+		]
+	};
+
+	const validationError = new ValidationError(validationErrors);
+
+	t.equal(validationError.name, "JsonSchemaValidationError");
+	t.same(validationError.validationErrors, validationErrors);
 });


### PR DESCRIPTION
## Summary
- add runtime coverage for direct `ValidationError` construction
- add a type regression test that packs and installs the current package into a temp consumer
- keep issue #90 closure evidence in the repo test suite

## Why
Issue #90 reported that `new ValidationError({...})` was typed like the built-in `Error` constructor and only accepted a string.

I reproduced that behavior against the published `2.1.1` package, where TypeScript fails with:

```text
error TS2345: Argument of type ... is not assignable to parameter of type 'string'.
```

I then verified that both:
- the current source in this repository
- the published `3.0.1` package

accept the same construction at both type-check and runtime.

Closes #90.

## Testing
- `npm test`
- repro script against published `2.1.1`, local package tarball, and published `3.0.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test infrastructure and add no runtime/library behavior changes, but they do add a packaging-based typecheck step that could be brittle in CI if npm/pack behavior differs.
> 
> **Overview**
> Adds regression coverage to ensure `ValidationError` can be constructed with AJV-style error objects at both runtime and from the published type declarations.
> 
> Replaces the old `tsc`-against-`src/index.d.ts` type test with a new `scripts/test-types.js` that packs the current package, installs it into a temporary consumer project with a pinned TypeScript version, and type-checks a small `validation-error.ts` usage snippet. Also extends unit tests to directly construct `new ValidationError(...)` and assert its `name` and `validationErrors` payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 288ec576e53e111dc010413940b593ecb9631e64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->